### PR TITLE
HH-71647 jsonp callback validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - python: "3.3"
     - python: "3.4"
     - python: "3.5"
+    - python: "3.6"
 install:
   - pip install codecov
   - python setup.py install

--- a/hhwebutils/js_validator.py
+++ b/hhwebutils/js_validator.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+import re
+from unicodedata import category
+
+from hhwebutils.compat import unicode_type, unicode_chr
+
+# Placed into the Public Domain by tav <tav@espians.com>
+# Validate Javascript Identifiers for use as JSON-P callback parameters.
+
+# javascript identifier unicode categories and "exceptional" chars
+valid_jsid_categories_start = frozenset(['Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nl'])
+valid_jsid_categories = frozenset(['Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nl', 'Mn', 'Mc', 'Nd', 'Pc'])
+valid_jsid_chars = ('$', '_')
+
+# regex to find array[index] patterns
+array_index_regex = re.compile(r'\[[0-9]+\]$')
+
+has_valid_array_index = array_index_regex.search
+replace_array_index = array_index_regex.sub
+
+# javascript reserved words -- including keywords and null/boolean literals
+is_reserved_js_word = frozenset([
+    'abstract', 'boolean', 'break', 'byte', 'case', 'catch', 'char', 'class',
+    'const', 'continue', 'debugger', 'default', 'delete', 'do', 'double',
+    'else', 'enum', 'export', 'extends', 'false', 'final', 'finally', 'float',
+    'for', 'function', 'goto', 'if', 'implements', 'import', 'in', 'instanceof',
+    'int', 'interface', 'let', 'long', 'native', 'new', 'null', 'package', 'private',
+    'protected', 'public', 'return', 'short', 'static', 'super', 'switch',
+    'synchronized', 'this', 'throw', 'throws', 'transient', 'true', 'try',
+    'typeof', 'var', 'void', 'volatile', 'while', 'with',
+    'yield']).__contains__
+
+
+def is_valid_js_identifier(identifier, escape=r'\u', ucd_cat=category):
+    """Return whether the given ``id`` is a valid Javascript identifier."""
+
+    if not identifier:
+        return False
+
+    if not isinstance(identifier, unicode_type):
+        try:
+            identifier = unicode_type(identifier, 'utf-8')
+        except UnicodeDecodeError:
+            return False
+
+    if escape in identifier:
+        new = []
+        add_char = new.append
+        split_id = identifier.split(escape)
+        add_char(split_id.pop(0))
+
+        for segment in split_id:
+            if len(segment) < 4:
+                return False
+            try:
+                add_char(unicode_chr(int('0x' + segment[:4], 16)))
+            except Exception:
+                return False
+            add_char(segment[4:])
+
+        identifier = u''.join(new)
+
+    if is_reserved_js_word(identifier):
+        return False
+
+    first_char = identifier[0]
+
+    if not ((first_char in valid_jsid_chars) or
+            (ucd_cat(first_char) in valid_jsid_categories_start)):
+        return False
+
+    for char in identifier[1:]:
+        if not ((char in valid_jsid_chars) or
+                (ucd_cat(char) in valid_jsid_categories)):
+            return False
+
+    return True
+
+
+def is_valid_jsonp_callback_value(value):
+    """Return whether the given ``value`` can be used as a JSON-P callback."""
+
+    for identifier in value.split(u'.'):
+        while '[' in identifier:
+            if not has_valid_array_index(identifier):
+                return False
+            identifier = replace_array_index(u'', identifier)
+        if not is_valid_js_identifier(identifier):
+            return False
+
+    return True

--- a/hhwebutils_tests/__init__.py
+++ b/hhwebutils_tests/__init__.py
@@ -1,1 +1,4 @@
 # coding=utf-8
+import os.path
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/hhwebutils_tests/test_js_validator.py
+++ b/hhwebutils_tests/test_js_validator.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+from unittest import TestCase
+
+from hhwebutils.js_validator import is_valid_jsonp_callback_value, is_valid_js_identifier
+from hhwebutils.compat import unicode_type
+
+
+class IsValidJsonpCallbackValue(TestCase):
+
+    def test_good_callback(self):
+        self.assertTrue(is_valid_jsonp_callback_value('somevar'))
+
+    def test_bad_callbacks(self):
+        for cb in ('function', ' somevar'):
+            self.assertFalse(is_valid_jsonp_callback_value(cb))
+
+    def test_nested_level_callback(self):
+        self.assertFalse(is_valid_jsonp_callback_value('$.23'))
+        self.assertTrue(is_valid_jsonp_callback_value('$.ajaxHandler'))
+
+    def test_array_index_callback(self):
+        for cb in ('array_of_functions[42]foo[1]', 'array_of_functions[]', 'array_of_functions["key"]'):
+            self.assertFalse(is_valid_jsonp_callback_value(cb))
+        for cb in ('array_of_functions[42]', 'array_of_functions[42][1]'):
+            self.assertTrue(is_valid_jsonp_callback_value(cb))
+
+
+class IsValidJsIdentifierTestCase(TestCase):
+
+    def test_valid_identifier(self):
+        for val in (u'myfunc', u'Stra\u00dfe', unicode_type(u'привет').encode('utf-8')):
+            self.assertTrue(is_valid_js_identifier(val))
+
+    def test_invalid_identifier_unicode_errors(self):
+        self.assertFalse(is_valid_js_identifier(unicode_type(u'привет').encode('utf-16')))
+
+    def test_reserved_words(self):
+        for val in ('yield', 'for'):
+            self.assertFalse(is_valid_js_identifier(val))

--- a/hhwebutils_tests/test_pycodestyle.py
+++ b/hhwebutils_tests/test_pycodestyle.py
@@ -1,8 +1,11 @@
 # coding=utf-8
 
 import unittest
+import os.path
 
 import pycodestyle
+
+from hhwebutils_tests import PROJECT_DIR
 
 
 class TestPycodestyle(unittest.TestCase):
@@ -16,5 +19,5 @@ class TestPycodestyle(unittest.TestCase):
             ignore=['E731']
         )
 
-        result = style_guide.check_files(TestPycodestyle.CHECKED_FILES)
+        result = style_guide.check_files([os.path.join(PROJECT_DIR, p) for p in TestPycodestyle.CHECKED_FILES])
         self.assertEqual(result.total_errors, 0, 'Pycodestyle found code style errors or warnings')


### PR DESCRIPTION
Вынес и портировал на python3 код из hhapi.

https://jira.hh.ru/browse/HH-71647

Проверяет callback для jsonp. Внутри есть также выделенная фукнция для проверки идентификаторов js, но отдельно она мало полезна.


Дополнительно сделал:
* тестирование в python 3.6
* не зависящий от CWD тест на стиль