### PR TITLE
HH-74820 add backurl validation method

### DIFF
--- a/hhwebutils/url_validator.py
+++ b/hhwebutils/url_validator.py
@@ -15,56 +15,104 @@ INVALID_CHARACTERS_REGEXP = re.compile('[' + ''.join(_invalid_characters) + ']' 
 VALID_SCHEMES = ('http', 'https')
 
 
-class UrlValidationException(Exception):
-    pass
-
-
 def validate(url, level='error'):
     """
     Validate and try to fix url
+    Url can lead to any host
 
     level can take following values:
         error: return None if url is invalid
         validate: try to fix scheme
-        filter: remove invaid charecters and fix scheme
+        filter: remove invalid characters and fix scheme
+    """
+    return _validate(url, level)
+
+
+def validate_backurl(backurl, permitted_hosts, permitted_schemes, fallback='/'):
+    """
+    Validate and try to fix backurl
+    Backurl can be relative
+    otherwise must lead to permitted host or permitted scheme
     """
 
-    def sanitize_value(url):
-        if url is None or not isinstance(url, (bytes, unicode_type)):
-            raise UrlValidationException
+    return _validate(
+        backurl,
+        level='filter',
+        fallback=fallback,
+        default_scheme='https',
+        permitted_hosts=permitted_hosts,
+        permitted_schemes=permitted_schemes,
+        allow_relative_urls=True
+    )
 
-        return url
+
+def is_permitted_scheme(url, permitted_schemes):
+    """
+    Check if url leads to permitted scheme
+    """
+    if not url:
+        return False
+
+    return urlparse.urlsplit(unquote(url)).scheme in permitted_schemes
+
+
+def _validate(
+        url,
+        level='error',
+        fallback=None,
+        default_scheme='http',
+        permitted_hosts=None,
+        permitted_schemes=None,
+        allow_relative_urls=False):
+
+    def sanitize_value(url):
+        if not url or not isinstance(url, (bytes, unicode_type)):
+            return fallback
+
+        return sanitize_characters(url)
 
     def sanitize_characters(url):
         if INVALID_CHARACTERS_REGEXP.search(url) is not None:
             if level == 'filter':
-                return INVALID_CHARACTERS_REGEXP.sub('', url)
+                return sanitize_scheme(INVALID_CHARACTERS_REGEXP.sub('', url))
             else:
-                raise UrlValidationException
+                return fallback
 
-        return url
+        return sanitize_scheme(url)
 
     def sanitize_scheme(url):
-        if urlparse.urlsplit(unquote(url)).scheme not in VALID_SCHEMES:
+        if permitted_schemes is not None and is_permitted_scheme(url, permitted_schemes):
+            return url
+
+        scheme = urlparse.urlsplit(unquote(url)).scheme
+        if not scheme and allow_relative_urls:
+            return url
+        if scheme not in VALID_SCHEMES:
             if level in ('validate', 'filter'):
                 parts = urlparse.urlsplit(url)
                 url = urlparse.urlunsplit(('', parts.netloc, parts.path, parts.query, parts.fragment))
-                return urlparse.urljoin('http:', re.sub('^/*', '//', url))
+                return sanitize_path(urlparse.urljoin('{}:'.format(default_scheme), re.sub('^/*', '//', url)))
             else:
-                raise UrlValidationException
+                return fallback
 
-        return url
+        return sanitize_path(url)
 
     def sanitize_path(url):
         parts = urlparse.urlsplit(unquote(url))
 
         if parts.hostname is None or parts.hostname == '':
-            raise UrlValidationException
+            return fallback
+
+        if permitted_hosts is not None:
+            host = parts.netloc
+            if not any(
+                host == valid_host or host.endswith('.' + valid_host) for valid_host in permitted_hosts
+            ):
+                return fallback
 
         return url
 
     try:
-        validation_functions = (sanitize_value, sanitize_characters, sanitize_scheme, sanitize_path)
-        return reduce(lambda url, validator: validator(url), validation_functions, url)
-    except (ValueError, UrlValidationException):
+        return sanitize_value(url)
+    except ValueError:
         return None


### PR DESCRIPTION
Выношу сюда из xhh метод валидации бэкурла
https://github.com/hhru/hh.sites.main/blob/5b5bb12fc0f6a654d9de7841e74c2c080f350b48/xhh/utils/validate_url.py#L6
чтобы можно было его заюзать в других репах, например в hhmobile

В отличии от validate, validate_backurl проверяет что урл ведет на наш домен или наше приложение, а также разрешает относительные урлы
