### PR TITLE
HH-78568 Добавлен модуль перевода из минут назад в человекочитаемую форму

### DIFF
--- a/hhwebutils/minutes_ago_to_human_readable.py
+++ b/hhwebutils/minutes_ago_to_human_readable.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+
+
+def convert_to_readable(minutes):
+    now = datetime.now()
+    stamp = now - timedelta(minutes=minutes)
+    today_beginning = datetime(now.year, now.month, now.day)
+    is_today = stamp > today_beginning
+
+    diff = today_beginning - stamp
+    diff_days = diff.days + 1
+
+    if minutes == 0:
+        time_code = 'online'
+    elif is_today:
+        time_code = 'today'
+    elif diff_days == 1:
+        time_code = 'yesterday'
+    elif diff_days <= 7:
+        time_code = 'weekExact'
+    elif diff_days <= 30:
+        time_code = 'week'
+    else:
+        time_code = 'month'
+
+    return {
+        'time_code': time_code,
+        'days_ago': diff_days
+    }

--- a/hhwebutils_tests/test_minutes_ago_to_human_readable.py
+++ b/hhwebutils_tests/test_minutes_ago_to_human_readable.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+
+import unittest
+from datetime import datetime, date, time
+from freezegun import freeze_time
+
+from hhwebutils.minutes_ago_to_human_readable import convert_to_readable
+
+
+def get_day_minutes_since_start():
+    now = datetime.now()
+    today_beginning = datetime(now.year, now.month, now.day)
+    diff = now - today_beginning
+    return int(diff.seconds / 60)
+
+
+@freeze_time("2018-07-03 00:10:01")
+class TestMinutesAgoConversion(unittest.TestCase):
+    def check(self, diff, time_code, days_ago):
+        self.assertEqual(convert_to_readable(diff), {'time_code': time_code, 'days_ago': days_ago})
+
+    def test_format(self):
+        self.assertEqual(convert_to_readable(0), {'time_code': 'online', 'days_ago': 0})
+
+    def test_time_codes(self):
+        start_minutes = get_day_minutes_since_start()
+        full_day_minutes = 60 * 24
+
+        self.check(0, 'online', 0)
+        self.check(5, 'today', 0)
+        self.check(10, 'today', 0)
+        self.check(start_minutes, 'today', 0)
+        self.check(start_minutes + 1, 'yesterday', 1)
+        self.check(start_minutes + full_day_minutes, 'yesterday', 1)
+        self.check(start_minutes + full_day_minutes + 1, 'weekExact', 2)
+        self.check(start_minutes + (full_day_minutes * 7), 'weekExact', 7)
+        self.check(start_minutes + (full_day_minutes * 7) + 1, 'week', 8)
+        self.check(start_minutes + (full_day_minutes * 30), 'week', 30)
+        self.check(start_minutes + (full_day_minutes * 30) + 1, 'month', 31)
+        self.check(start_minutes + (full_day_minutes * 100), 'month', 100)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     tests_require=[
         'nose',
         'lxml-asserts',
-        'pycodestyle == 2.0.0'
+        'pycodestyle == 2.0.0',
+        'freezegun'
     ],
     zip_safe=False
 )


### PR DESCRIPTION
Описание форматов времени: https://jira.hh.ru/browse/PORTFOLIO-4530

Была задача переводить количество минут, прошедшее от текущего момента в человекочитаемый вид формата:

```
сейчас онлайн
был сегодня
был вчера
был 2(-7) дней назад
был больше недели назад
был более месяца назад
```

Добавил функцию, возвращающую код формата (используется в переводах) и количество дней, прошедшее с текущего момента времени (используется для случая `2(-7) дней назад`).

Выношу сюда, т.к. будет использоваться в xhh и hhmobile