### PR TITLE
HH-87531 Make UUID parsing rules a bit broader

### DIFF
--- a/hhwebutils/mobile_device_uuid.py
+++ b/hhwebutils/mobile_device_uuid.py
@@ -1,7 +1,6 @@
 import re
 
-# 01234567-89ab-cdef-0123-456789abcdef
-UUID_RE = re.compile('UUID:? ([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})', re.I)
+UUID_RE = re.compile('UUID:? ([\w\-]+)', re.I)
 
 
 def parse_uuid(user_agent):

--- a/hhwebutils_tests/test_mobile_device_uuid.py
+++ b/hhwebutils_tests/test_mobile_device_uuid.py
@@ -16,7 +16,10 @@ class TestUrls(unittest.TestCase):
 
         'Mozilla/5.0 (Linux; Android 8.0.0; AUM-L29 Build/HONORAUM-L29; wv) AppleWebKit/537.36 (KHTML, like Gecko) '
         'Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36 ru.hh.android/5.2.1.387, Device: AUM-L29, Android OS: '
-        '8.0.0 (UUID {})'
+        '8.0.0 (UUID {})',
+
+        'hh-justai-full-bot/1.0, channel: telegram UUID: {}',
+        'hh-justai-full-bot/1.0, channel: telegram UUID {}',
     ]
 
     def test_uppercase_uuid_parse(self):
@@ -26,6 +29,11 @@ class TestUrls(unittest.TestCase):
 
     def test_lowercase_uuid_parse(self):
         uuid_in_text = 'd7b64537-bfd1-4981-8b25-6c09e1163a3e'
+        for ua in self.user_agents_patterns:
+            self.assertEqual(uuid_in_text.upper(), parse_uuid(ua.format(uuid_in_text)))
+
+    def test_uuid_without_dashes_parse(self):
+        uuid_in_text = '3922ad0a1b223fad50b8e43abb13cc35'
         for ua in self.user_agents_patterns:
             self.assertEqual(uuid_in_text.upper(), parse_uuid(ua.format(uuid_in_text)))
 


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-87531

Парсинг UUID был заточен под формат UUID, разбитый дефисами. От некоторых клиентов он может прилетать в произвольном формате, так что я обновил регулярку, которая его парсит.