### PR TITLE
HH-208378 add method to replace invalid xml chars

### DIFF
--- a/hhwebutils/xml.py
+++ b/hhwebutils/xml.py
@@ -38,6 +38,10 @@ def xml_to_string(node, clean_xmlns=False, method='xml'):
 
 
 def strip_invalid_characters(string):
+    return replace_invalid_characters(string, replacement=u'')
+
+
+def replace_invalid_characters(string, *, replacement=u'\uFFFD'):
     if string is None:
         return u''
 
@@ -47,4 +51,6 @@ def strip_invalid_characters(string):
     elif not isinstance(string, unicode_type):
         string = unicode_type(string)
 
-    return _INVALID_CHARACTERS_REGEXP.sub(u'', string)
+    escaped_replacement = replacement.replace(u'\\', u'\\\\')
+
+    return _INVALID_CHARACTERS_REGEXP.sub(escaped_replacement, string)

--- a/hhwebutils_tests/test_xml.py
+++ b/hhwebutils_tests/test_xml.py
@@ -1,11 +1,10 @@
 # coding=utf-8
-import sys
 import unittest
 
 from lxml import etree
 
 from hhwebutils.compat import unicode_type, unicode_chr
-from hhwebutils.xml import xml_to_string, strip_invalid_characters
+from hhwebutils.xml import xml_to_string, strip_invalid_characters, replace_invalid_characters
 
 
 def is_unicode_32bit_supported():
@@ -198,3 +197,13 @@ class StripInvalidCharactersTestCaseTestCase(unittest.TestCase):
 
     def test_none(self):
         self.assertEqual(strip_invalid_characters(None), u'')
+
+    def test_replace(self):
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty\uFFFEasd'), u'qwe\uFFFDrty\uFFFDasd')
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty\uFFFEasd', replacement=u''), u'qwertyasd')
+
+    def test_replace_with_slashes(self):
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty', replacement=u'aa\\bb'), u'qweaa\\bbrty')
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty', replacement=u'aa\\bb\ncc'), u'qweaa\\bb\nccrty')
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty', replacement=u'aa\\bb\\cc'), u'qweaa\\bb\\ccrty')
+        self.assertEqual(replace_invalid_characters(u'qwe\uFFFFrty', replacement=u'aa\\bb\\11'), u'qweaa\\bb\\11rty')


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-208378

Добавил функцию, которая умеет заменять невалидные xml-символы на что-то другое (раньше была только функция, которая умеет вырезать).

- [x] **version change**: MINOR
- [x] **description**: Добавлена функция, которая умеет заменять невалидные xml-символы в строке на что-то другое.
- [x] **requires_changes_in_hh**: false
